### PR TITLE
 Libfontmanager: Fix for library dependency.

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -527,13 +527,13 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     LDFLAGS_unix := -L$(INSTALL_LIBRARIES_HERE), \
     LDFLAGS_aix := -Wl$(COMMA)-berok, \
     LIBS := $(BUILD_LIBFONTMANAGER_FONTLIB), \
-    LIBS_unix := -lawt -lawt_headless -ljava -ljvm $(LIBM) $(LIBCXX), \
+    LIBS_unix := -lawt -lawt_xawt -ljava -ljvm -lc $(LIBM) $(LIBCXX), \
     LIBS_macosx := -lawt_lwawt -framework CoreText -framework CoreFoundation -framework CoreGraphics, \
     LIBS_windows := $(WIN_JAVA_LIB) advapi32.lib user32.lib gdi32.lib \
         $(WIN_AWT_LIB), \
 ))
 
-$(BUILD_LIBFONTMANAGER): $(BUILD_LIBAWT)
+$(BUILD_LIBFONTMANAGER): $(BUILD_LIBAWT) $(BUILD_LIBAWT_XAWT)
 
 ifeq ($(call isTargetOs, macosx), true)
   $(BUILD_LIBFONTMANAGER): $(call FindLib, $(MODULE), awt_lwawt)


### PR DESCRIPTION
This commit base is from: https://github.com/androidports/openjdk/commit/a3e4f0281154537f01c2e59286a6ceed9c827b11

* Needed to have working gui support.